### PR TITLE
Use .removeChild() instead of .remove() for compatibility with IE

### DIFF
--- a/src/inline-svg.directive.ts
+++ b/src/inline-svg.directive.ts
@@ -140,8 +140,9 @@ export class InlineSVGDirective implements OnInit, OnChanges, OnDestroy {
   /** @internal */
   private _insertEl(el: Element) {
     if (this.replaceContents && !this.prepend) {
-      if (this._prevSVG) {
-        this._prevSVG.remove();
+      const parentNode = this._prevSVG && this._prevSVG.parentNode;
+      if (parentNode) {
+        parentNode.removeChild(this._prevSVG);
       }
 
       this._el.nativeElement.innerHTML = '';


### PR DESCRIPTION
http://stackoverflow.com/questions/18919560/object-doesnt-support-property-or-method-remove