### PR TITLE
fix(NgInlineSvg): compatibility with Angular 4.3

### DIFF
--- a/src/inline-svg.module.ts
+++ b/src/inline-svg.module.ts
@@ -1,5 +1,5 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
-import { HttpModule } from '@angular/http';
+import { HttpClientModule } from '@angular/common/http';
 
 import { InlineSVGComponent } from './inline-svg.component';
 import { InlineSVGDirective } from './inline-svg.directive';
@@ -7,7 +7,7 @@ import { InlineSVGConfig, SVGCacheService } from './svg-cache.service';
 
 @NgModule({
   declarations: [InlineSVGDirective, InlineSVGComponent],
-  imports: [HttpModule],
+  imports: [HttpClientModule],
   exports: [InlineSVGDirective],
   providers: [SVGCacheService],
   entryComponents: [InlineSVGComponent]

--- a/src/svg-cache.service.ts
+++ b/src/svg-cache.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Optional } from '@angular/core';
-import { Http, Response } from '@angular/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/catch';
@@ -20,7 +20,7 @@ export class SVGCacheService {
 
   constructor(
     @Optional() config: InlineSVGConfig,
-    private _http: Http) {
+    private _http: HttpClient) {
     if (!SVGCacheService._baseUrl) {
       this.setBaseUrl(config);
     }
@@ -48,8 +48,7 @@ export class SVGCacheService {
     }
 
     // Otherwise, make the HTTP call to fetch
-    const req = this._http.get(absUrl)
-      .map((res: Response) => res.text())
+    const req = this._http.get(absUrl, {responseType: 'text'})
       .catch((err: any) => err)
       .finally(() => {
         SVGCacheService._inProgressReqs.delete(absUrl);


### PR DESCRIPTION
BREAKING CHANGE: the module is now only compatible with Angular 4.3+ because it uses `HttpClient` instead of `Http`

Changes code so that it uses Angular's new `HttpClient` module instead of the soon to be deprecated `Http` module. Allows alls users of Angular 4.3+ to move to the new http module without having to package both, the old and the new modules, in production builds.