### PR TITLE
Use app base href by default

### DIFF
--- a/src/inline-svg.config.ts
+++ b/src/inline-svg.config.ts
@@ -1,0 +1,20 @@
+import { Inject, Optional } from '@angular/core';
+import { PlatformLocation, APP_BASE_HREF } from '@angular/common';
+
+export class InlineSVGConfig {
+    baseUrl: string;
+}
+
+export class InlineSVGDefaultConfig extends InlineSVGConfig {
+    constructor(
+        @Optional() @Inject(APP_BASE_HREF) appBase: string,
+        @Optional() location: PlatformLocation,
+    ) {
+        super();
+        if (appBase !== null) {
+            this.baseUrl = appBase;
+        } else if (location !== null) {
+            this.baseUrl = location.getBaseHrefFromDOM();
+        }
+    }
+}

--- a/src/inline-svg.module.ts
+++ b/src/inline-svg.module.ts
@@ -1,13 +1,16 @@
 import { NgModule, ModuleWithProviders } from '@angular/core';
-
+import { InlineSVGConfig, InlineSVGDefaultConfig } from './inline-svg.config';
 import { InlineSVGComponent } from './inline-svg.component';
 import { InlineSVGDirective } from './inline-svg.directive';
-import { InlineSVGConfig, SVGCacheService } from './svg-cache.service';
+import { SVGCacheService } from './svg-cache.service';
 
 @NgModule({
   declarations: [InlineSVGDirective, InlineSVGComponent],
   exports: [InlineSVGDirective],
-  providers: [SVGCacheService],
+  providers: [
+    SVGCacheService,
+    {provide: InlineSVGConfig, useClass: InlineSVGDefaultConfig},
+  ],
   entryComponents: [InlineSVGComponent]
 })
 export class InlineSVGModule {

--- a/src/svg-cache.service.ts
+++ b/src/svg-cache.service.ts
@@ -6,23 +6,20 @@ import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/finally';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/share';
-
-export class InlineSVGConfig {
-  baseUrl: string;
-}
+import { InlineSVGConfig } from './inline-svg.config';
 
 @Injectable()
 export class SVGCacheService {
   private static _cache: Map<string, SVGElement>;
   private static _inProgressReqs: Map<string, Observable<SVGElement>>;
 
-  private static _baseUrl: string;
+  private _baseUrl: string;
 
   constructor(
     @Optional() config: InlineSVGConfig,
     private _http: HttpClient) {
-    if (!SVGCacheService._baseUrl) {
-      this.setBaseUrl(config);
+    if (config) {
+      this._baseUrl = config.baseUrl;
     }
 
     if (!SVGCacheService._cache) {
@@ -65,16 +62,10 @@ export class SVGCacheService {
     return req;
   }
 
-  setBaseUrl(config: InlineSVGConfig): void {
-    if (config) {
-      SVGCacheService._baseUrl = config.baseUrl;
-    }
-  }
-
   private _getAbsoluteUrl(url: string): string {
     // Prepend user-configured base if present
-    if (SVGCacheService._baseUrl) {
-      url = SVGCacheService._baseUrl + url;
+    if (this._baseUrl) {
+      url = this._baseUrl + url;
     }
 
     const base = document.createElement('BASE') as HTMLBaseElement;


### PR DESCRIPTION
Issue arkon/ng-inline-svg#48

When using `InlineSVGModule` itself (not `InlineSVGModule.forRoot()`) set base URL:
1. from `APP_BASE_HREF` if available;
2. from `<base>` tag (if available).
