### PR TITLE
fix misusing of rxjs catchError in svg cache service

### DIFF
--- a/src/svg-cache.service.ts
+++ b/src/svg-cache.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Optional, Renderer2, RendererFactory2 } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
-import { map, finalize, catchError, share } from 'rxjs/operators';
+import { map, finalize, share } from 'rxjs/operators';
 
 
 import { InlineSVGConfig } from './inline-svg.config';
@@ -50,7 +50,6 @@ export class SVGCacheService {
     // Otherwise, make the HTTP call to fetch
     const req = this._http.get(absUrl, {responseType: 'text'})
       .pipe(
-        catchError((err: any) => err),
         finalize(() => {
           SVGCacheService._inProgressReqs.delete(absUrl);
         }),


### PR DESCRIPTION
ng-inline-svg v7.0.0 throws an unhandeled exception if a given svg is not available.

This is because the rxjs catchError operator expects an Observable as return type [RxDocs#catchError](http://reactivex.io/rxjs/function/index.html#static-function-catchError). In the actual code the error object is returned instead of an observable.

This PR removes the catchError operator from the svg cache service because errors of svg-cache-service.getSVG() gets already handeled correctly in the subscription in inline-svg.directives.ts