### PR TITLE
Fix: DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.

### DIFF
--- a/src/inline-svg.directive.ts
+++ b/src/inline-svg.directive.ts
@@ -210,7 +210,7 @@ export class InlineSVGDirective implements OnInit, OnChanges, OnDestroy {
       if (!scriptType || scriptType === 'application/ecmascript' || scriptType === 'application/javascript') {
         script = scripts[i].innerText || scripts[i].textContent;
         scriptsToEval.push(script);
-        svg.removeChild(scripts[i]);
+        this._renderer.removeChild(scripts[i].parentNode, scripts[i]);
       }
     }
 


### PR DESCRIPTION
Steps to reproduce:
Add more than one inlineSVG instances with scripts on the same Angular page.