### PR TITLE
added fix for removeSVGAttributes

### DIFF
--- a/demo/src/demo/demo.component.ts
+++ b/demo/src/demo/demo.component.ts
@@ -5,7 +5,7 @@ import { Component, OnInit } from '@angular/core';
   template: `
     <div class="demo-svg1" aria-label="My icon 1" [inlineSVG]="'img/image.svg'" [onSVGLoaded]="handleSVG" [removeSVGAttributes]="['xmlns']"></div>
     <div class="demo-svg2" aria-label="My icon 2" [inlineSVG]="'img/image.svg'" [replaceContents]="true" [setSVGAttributes]="_attrs">Content</div>
-    <div *ngIf="_showOther" class="demo-svg3" aria-label="My delayed icon" [inlineSVG]="'img/image_with_fill.svg'" [removeSVGAttributes]="['fill']"></div>
+    <div *ngIf="_showOther" class="demo-svg3" aria-label="My delayed icon" [inlineSVG]="'img/image_with_fill.svg'" [removeSVGAttributes]="['fill', 'width', 'height']"></div>
     <div [inlineSVG]="'img/symbol.svg#fish'"></div>
     <div [inlineSVG]="'#fish'"></div>
     <div [inlineSVG]="'#fish'" [injectComponent]="true"></div>

--- a/src/svg-util.ts
+++ b/src/svg-util.ts
@@ -51,6 +51,7 @@ export function removeAttributes(element: Element, attrs: Array<string>): void {
   for (let i = 0; i < svgAttrs.length; i++) {
     if (attrs.indexOf(svgAttrs[i].name.toLowerCase()) > -1) {
       element.removeAttribute(svgAttrs[i].name);
+      i--;
     }
   }
 


### PR DESCRIPTION
Hi, I've found the problem with removing SVG attributes, when I'm trying to remove two or more attributes. I checked "removedAttributes" function and find that you removing the element using the index in the "for" loop, after removing the element from"svgAttrs" the next element will change position to the position of the removing item and not checked at the next iteration of the loop, so this element will be skipped. Could you please check your code.

p.s.: it's just a quick decision from my side.