### PR TITLE
feat(svg-cache): use httpbackend to skip interceptor chain

### DIFF
--- a/src/svg-cache.service.ts
+++ b/src/svg-cache.service.ts
@@ -1,10 +1,10 @@
-import { Inject, Injectable, Optional, Renderer2, RendererFactory2 } from '@angular/core';
 import { APP_BASE_HREF, PlatformLocation } from '@angular/common';
-import { HttpClient } from '@angular/common/http';
+import { HttpBackend, HttpClient } from '@angular/common/http';
+import { Inject, Injectable, Optional, Renderer2, RendererFactory2 } from '@angular/core';
 import { Observable, of } from 'rxjs';
-import { map, finalize, share } from 'rxjs/operators';
-
+import { finalize, map, share } from 'rxjs/operators';
 import { InlineSVGConfig } from './inline-svg.config';
+
 
 @Injectable({
   providedIn: 'root'
@@ -15,14 +15,17 @@ export class SVGCacheService {
 
   private _baseUrl: string;
 
+  private _http: HttpClient;
+
   private _renderer: Renderer2;
 
   constructor(
     @Optional() @Inject(APP_BASE_HREF) private _appBase: string,
     @Optional() private _location: PlatformLocation,
     @Optional() private _config: InlineSVGConfig,
-    private _http: HttpClient,
+    private httpBackend: HttpBackend,
     rendererFactory: RendererFactory2) {
+    this._http = new HttpClient(this.httpBackend);
     this._renderer = rendererFactory.createRenderer(null, null);
 
     this.setBaseUrl();


### PR DESCRIPTION
Closes https://github.com/arkon/ng-inline-svg/issues/121