### PR TITLE
peer dependency update keeps @angular within the major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "prepare": "npm run build"
   },
   "peerDependencies": {
-    "@angular/core": ">=8.0.0",
-    "@angular/common": ">=8.0.0",
+    "@angular/core": "^8.0.0 || ^9.0.0",
+    "@angular/common": "^8.0.0 || ^9.0.0",
     "rxjs": "^6.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
setting the peer dependency of @angular/core >=8.0.0 caused ng update to fail and when forced would pull in @angular/core@9.0.0-next.0

setting the range to ^8.0.0 || ^9.0.0 but wont pull next/rc releases