### PR TITLE
Release/v8.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-inline-svg",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-inline-svg",
-  "version": "8.6.0",
+  "version": "8.6.1",
   "description": "Angular directive for inserting an SVG inline within an element.",
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "es2015",
+    "module": "commonjs",
     "moduleResolution": "node",
     "noUnusedParameters": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
Reverting commit that changes `tsconfig.compilerOptions.module `back to `commonjs` and creating new tag v8.6.1 for angular7 users.

Branch should not be master, but I cannot create one in your repo.