### PR TITLE
Caching of SVG when using symbols (fixes #133)

### DIFF
--- a/src/svg-cache.service.ts
+++ b/src/svg-cache.service.ts
@@ -42,9 +42,9 @@ export class SVGCacheService {
   }
 
   getSVG(url: string, resolveSVGUrl: boolean, cache: boolean = true): Observable<SVGElement> {
-    const svgUrl = resolveSVGUrl
+    const svgUrl = (resolveSVGUrl
       ? this.getAbsoluteUrl(url)
-      : url;
+      : url).replace(/#.+$/, '');
 
     // Return cached copy if it exists
     if (cache && SVGCacheService._cache.has(svgUrl)) {


### PR DESCRIPTION
PR to fix #133:

Remove the symbol part so we are able to cache the SVG file itself.