### PR TITLE
Adding fallbackSVG Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The SVG file (if found) will be inserted *inside* the element with the `[inlineS
 | forceEvalStyles | boolean | `false` | Forces embeded style tags' contents to be evaluated (for IE 11). |
 | evalScripts | `'always'`, `'once'`, `'none'` | `'always'` | Whether to evaluate embedded scripts in the loaded SVG files. The `SVGScriptEvalMode` enum is also provided. |
 | fallbackImgUrl | string | | URL for a regular image to be displayed as a fallback if the SVG fails to load. |
+| fallbackSVG | string | | SVG filename to be displayed as a fallback if the SVG fails to load. |
 | onSVGLoaded | `(svg: SVGElement, parent: Element \| null) => SVGElement` | | Lifecycle hook that allows the loaded SVG to be manipulated prior to insertion. |
 
 #### Outputs

--- a/demo/src/demo/demo.component.ts
+++ b/demo/src/demo/demo.component.ts
@@ -12,6 +12,7 @@ import { Component, OnInit } from '@angular/core';
     <div><button (click)="updateSize(10)">Increase</button><button (click)="updateSize(-10)">Decrease</button></div>
     <div [inlineSVG]="'#fish'" [setSVGAttributes]="_changeAttrs"></div>
     <div [inlineSVG]="'img/nope.svg'" [fallbackImgUrl]="'https://nodei.co/npm/ng-inline-svg.png?compact=true'"></div>
+    <div [inlineSVG]="'img/nope.svg'" [fallbackSVG]="'#fish'"></div>
   `
 })
 export class DemoComponent implements OnInit {

--- a/src/inline-svg.directive.ts
+++ b/src/inline-svg.directive.ts
@@ -199,7 +199,7 @@ export class InlineSVGDirective implements OnInit, OnChanges, OnDestroy {
       this._renderer.setAttribute(elImg, 'src', this.fallbackImgUrl);
 
       this._insertEl(elImg);
-    } else if (this.fallbackSVG && this.fallbackSVG !== this.inlineSVG ) {
+    } else if (this.fallbackSVG && this.fallbackSVG !== this.inlineSVG) {
       this.inlineSVG = this.fallbackSVG;
       this._insertSVG();
     }

--- a/src/inline-svg.directive.ts
+++ b/src/inline-svg.directive.ts
@@ -41,6 +41,7 @@ export class InlineSVGDirective implements OnInit, OnChanges, OnDestroy {
   @Input() forceEvalStyles: boolean = false;
   @Input() evalScripts: SVGScriptEvalMode = SVGScriptEvalMode.ALWAYS;
   @Input() fallbackImgUrl: string;
+  @Input() fallbackSVG: string;
   @Input() onSVGLoaded: (svg: SVGElement, parent: Element | null) => SVGElement;
 
   @Output() onSVGInserted: EventEmitter<SVGElement> = new EventEmitter<SVGElement>();
@@ -198,6 +199,9 @@ export class InlineSVGDirective implements OnInit, OnChanges, OnDestroy {
       this._renderer.setAttribute(elImg, 'src', this.fallbackImgUrl);
 
       this._insertEl(elImg);
+    } else if (this.fallbackSVG && this.fallbackSVG !== this.inlineSVG ) {
+      this.inlineSVG = this.fallbackSVG;
+      this._insertSVG();
     }
   }
 


### PR DESCRIPTION
Closes #165

Using this library within my company project, we had to generate the SVG file based on some data received from the backend.
In case of no corresponding SVG is present we handle it by defining the output onSVGFailed and we just switch the inlineSVG input with our fallbackSVG.

For this reason, I created this PR, in order to have the possibility to provide a fallbackSVG without handle it with the onSVGFailed output.

Have a nice day :)