### PR TITLE
Allow rxjs v7 in angular 12 projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "peerDependencies": {
     "@angular/core": "^12.0.0",
     "@angular/common": "^12.0.0",
-    "rxjs": "^6.6.0"
+    "rxjs": "^6.6.0 || ^7.4.0"
   },
   "devDependencies": {
     "@angular/common": "^12.0.0",


### PR DESCRIPTION
Even though Angular 12 shipped with rxjs v6, they made changes to support v7.

https://github.com/angular/angular/issues/41897
https://github.com/angular/angular/pull/42991
https://github.com/angular/angular/blob/fd1e7d4f0d73df42422caa056957aeaad2944a4a/packages/core/package.json#L19


When running `npm install` in an Angular 12 project with rxjs v7x, we get the following error.

```shell
npm ERR! Found: rxjs@7.4.0
npm ERR! node_modules/rxjs
npm ERR!   rxjs@"7.4.0" from the root project
npm ERR!   peer rxjs@"^6.5.3 || ^7.0.0" from @angular/common@12.2.12
npm ERR!   node_modules/@angular/common
npm ERR!     @angular/common@"12.2.12" from the root project
npm ERR!     peer @angular/common@"^12.0.0" from ng-inline-svg@13.1.0
npm ERR!     node_modules/ng-inline-svg
npm ERR!       ng-inline-svg@"13.1.0" from the root project
npm ERR!   1 more (@angular/core)
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer rxjs@"^6.6.0" from ng-inline-svg@13.1.0
npm ERR! node_modules/ng-inline-svg
npm ERR!   ng-inline-svg@"13.1.0" from the root project
```